### PR TITLE
Good Pinning Practices Metric completed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ECE461_Project",
+  "name": "ECE461_Project_Part2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/dependencies_factor/dependencies_factor.ts
+++ b/src/dependencies_factor/dependencies_factor.ts
@@ -1,0 +1,58 @@
+import {readFileSync} from 'fs';
+import {join} from 'path';
+
+export function check_if_pinned(dependency_version: string): boolean {
+  console.log(dependency_version);
+  const pinned_regex = /^=*\d+\.\d+/gm;
+  const match = dependency_version.match(pinned_regex);
+  console.log(match);
+  if (match === null) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
+export async function get_dependencies_score(
+  repo_url: string,
+  local_repo_path: string
+): Promise<number> {
+  try {
+    const package_json = JSON.parse(
+      readFileSync(join(local_repo_path, 'package.json')).toString()
+    );
+    const check_exists: string | undefined = package_json.dependencies;
+    if (check_exists !== null && check_exists !== undefined) {
+      const dependencies = JSON.parse(
+        JSON.stringify(package_json.dependencies)
+      );
+      globalThis.logger?.info(`${repo_url} has dependencies!`);
+      let num_dependencies = 0;
+      let num_pinned_dependencies = 0;
+      for (const dependency in dependencies) {
+        // eslint-disable-next-line no-prototype-builtins
+        if (dependencies.hasOwnProperty(dependency)) {
+          num_dependencies++;
+          if (check_if_pinned(dependencies[dependency])) {
+            num_pinned_dependencies++;
+          }
+        }
+      }
+      console.log(num_dependencies);
+      console.log(num_pinned_dependencies);
+      if (num_pinned_dependencies > 0) {
+        return 1 / num_pinned_dependencies;
+      } else {
+        return 1;
+      }
+    } else {
+      return 1;
+    }
+  } catch (err) {
+    if (err instanceof Error) {
+      console.log(err.message);
+      globalThis.logger?.error(`License Score calc got error: ${err.message}`);
+    }
+    return 0;
+  }
+}

--- a/src/dependencies_factor/dependencies_factor.ts
+++ b/src/dependencies_factor/dependencies_factor.ts
@@ -1,9 +1,11 @@
-import {readFileSync} from 'fs';
+import {readFile} from 'fs/promises';
 import {join} from 'path';
 
 export function check_if_pinned(dependency_version: string): boolean {
   console.log(dependency_version);
-  const pinned_regex = /^=*\d+\.\d+/gm;
+  //const pinned_regex = /^=*\d+\.\d+/gm;
+  const pinned_regex =
+    /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/gm;
   const match = dependency_version.match(pinned_regex);
   console.log(match);
   if (match === null) {
@@ -19,19 +21,18 @@ export async function get_dependencies_score(
 ): Promise<number> {
   try {
     const package_json = JSON.parse(
-      readFileSync(join(local_repo_path, 'package.json')).toString()
+      (await readFile(join(local_repo_path, 'package.json'))).toString()
     );
     const check_exists: string | undefined = package_json.dependencies;
     if (check_exists !== null && check_exists !== undefined) {
       const dependencies = JSON.parse(
         JSON.stringify(package_json.dependencies)
       );
-      globalThis.logger?.info(`${repo_url} has dependencies!`);
+
       let num_dependencies = 0;
       let num_pinned_dependencies = 0;
       for (const dependency in dependencies) {
-        // eslint-disable-next-line no-prototype-builtins
-        if (dependencies.hasOwnProperty(dependency)) {
+        if (Object.prototype.hasOwnProperty.call(dependencies, dependency)) {
           num_dependencies++;
           if (check_if_pinned(dependencies[dependency])) {
             num_pinned_dependencies++;
@@ -40,6 +41,9 @@ export async function get_dependencies_score(
       }
       console.log(num_dependencies);
       console.log(num_pinned_dependencies);
+      globalThis.logger?.info(
+        `${repo_url} has ${num_dependencies} dependencies and ${num_pinned_dependencies} pinned!`
+      );
       if (num_pinned_dependencies > 0) {
         return 1 / num_pinned_dependencies;
       } else {
@@ -51,8 +55,10 @@ export async function get_dependencies_score(
   } catch (err) {
     if (err instanceof Error) {
       console.log(err.message);
-      globalThis.logger?.error(`License Score calc got error: ${err.message}`);
+      globalThis.logger?.error(
+        `Dependencies Score calc got error, returning 1: ${err.message}`
+      );
     }
-    return 0;
+    return 1;
   }
 }

--- a/src/good_pinning_practice_factor/good_pinning_practice.ts
+++ b/src/good_pinning_practice_factor/good_pinning_practice.ts
@@ -42,7 +42,7 @@ export async function get_good_pinning_practice_score(
         `${repo_url} has ${num_dependencies} dependencies and ${num_pinned_dependencies} pinned!`
       );
       if (num_pinned_dependencies > 0) {
-        return 1 / num_pinned_dependencies;
+        return 1 / (1 + num_pinned_dependencies);
       } else {
         return 1;
       }
@@ -51,11 +51,10 @@ export async function get_good_pinning_practice_score(
     }
   } catch (err) {
     if (err instanceof Error) {
-      console.log(err.message);
       globalThis.logger?.error(
         `Dependencies Score calc got error, returning 1: ${err.message}`
       );
     }
-    return 1;
+    return 0;
   }
 }

--- a/src/good_pinning_practice_factor/good_pinning_practice.ts
+++ b/src/good_pinning_practice_factor/good_pinning_practice.ts
@@ -1,13 +1,12 @@
 import {readFile} from 'fs/promises';
 import {join} from 'path';
 
+// Regex from official semver exact versioning regex, and
+// https://gist.github.com/jhorsman/62eeea161a13b80e39f5249281e17c39
 export function check_if_pinned(dependency_version: string): boolean {
-  console.log(dependency_version);
-  //const pinned_regex = /^=*\d+\.\d+/gm;
   const pinned_regex =
     /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/gm;
   const match = dependency_version.match(pinned_regex);
-  console.log(match);
   if (match === null) {
     return false;
   } else {
@@ -15,7 +14,7 @@ export function check_if_pinned(dependency_version: string): boolean {
   }
 }
 
-export async function get_dependencies_score(
+export async function get_good_pinning_practice_score(
   repo_url: string,
   local_repo_path: string
 ): Promise<number> {
@@ -39,8 +38,6 @@ export async function get_dependencies_score(
           }
         }
       }
-      console.log(num_dependencies);
-      console.log(num_pinned_dependencies);
       globalThis.logger?.info(
         `${repo_url} has ${num_dependencies} dependencies and ${num_pinned_dependencies} pinned!`
       );

--- a/src/good_pinning_practice_factor/good_pinning_practice.ts
+++ b/src/good_pinning_practice_factor/good_pinning_practice.ts
@@ -3,7 +3,10 @@ import {join} from 'path';
 
 // Regex from official semver exact versioning regex, and
 // https://gist.github.com/jhorsman/62eeea161a13b80e39f5249281e17c39
+// method of testing https://regex101.com/r/F0H152/1
 export function check_if_pinned(dependency_version: string): boolean {
+  // figure out if tilde patching is valid spec
+  // figure out if 1.2.x is valid spec (is probably, this regex does not do this)
   const pinned_regex =
     /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/gm;
   const match = dependency_version.match(pinned_regex);

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {git_clone, create_tmp, delete_dir} from './git_clone';
 import {join} from 'path';
 import {get_ramp_up_score} from './ramp_up_factor/ramp_up';
 import {get_correctness_score} from './correctness/correctness';
+import {get_dependencies_score} from './dependencies_factor/dependencies_factor';
 
 const arrayToNdjson = require('array-to-ndjson');
 
@@ -18,6 +19,7 @@ interface SCORE_OUT {
   BusFactor: number;
   ResponsiveMaintainer: number;
   License: number;
+  Dependencies: number;
 }
 
 //get_license_score('git@github.com:davglass/license-checker.git').then(
@@ -48,6 +50,7 @@ async function score_calc(url_parse: URL_PARSE) {
     BusFactor: 0,
     ResponsiveMaintainer: 0,
     License: 0,
+    Dependencies: 0,
   };
   let temp_dir = '';
   try {
@@ -84,6 +87,11 @@ async function score_calc(url_parse: URL_PARSE) {
       url_parse.github_repo_url
     );
 
+    const dependencies_sub_score = get_dependencies_score(
+      url_parse.github_repo_url,
+      git_repo_path
+    );
+
     // Resolve subscores
     score.License = await license_sub_score;
     score.BusFactor = Number((await bus_factor_sub_score).toFixed(3));
@@ -92,8 +100,7 @@ async function score_calc(url_parse: URL_PARSE) {
     );
     score.RampUp = await ramp_up_sub_score;
     score.Correctness = await correctness_sub_score;
-
-    //console.log(score.Correctness);
+    score.Dependencies = await dependencies_sub_score;
 
     // Calculate subscores
     score.NetScore = net_score_formula(score);

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,9 @@ async function score_calc(url_parse: URL_PARSE) {
     );
     score.RampUp = Number((await ramp_up_sub_score).toFixed(3));
     score.Correctness = Number((await correctness_sub_score).toFixed(3));
-    score.GoodPinningPractice = Number((await good_pinning_practice_sub_score).toFixed(3));
+    score.GoodPinningPractice = Number(
+      (await good_pinning_practice_sub_score).toFixed(3)
+    );
 
     // Calculate subscores
     score.NetScore = Number(net_score_formula(score).toFixed(3));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {get_license_score} from './license_score_calc/license';
+pimport {get_license_score} from './license_score_calc/license';
 import {get_urls, URL_PARSE} from './url_parser';
 import {create_logger} from './logging_setup';
 import {get_bus_factor_score} from './bus_factor/bus_factor';
@@ -7,7 +7,7 @@ import {git_clone, create_tmp, delete_dir} from './git_clone';
 import {join} from 'path';
 import {get_ramp_up_score} from './ramp_up_factor/ramp_up';
 import {get_correctness_score} from './correctness/correctness';
-import {get_dependencies_score} from './dependencies_factor/dependencies_factor';
+import {get_good_pinning_practice_score} from './good_pinning_practice_factor/good_pinning_practice';
 
 const arrayToNdjson = require('array-to-ndjson');
 
@@ -19,7 +19,7 @@ interface SCORE_OUT {
   BusFactor: number;
   ResponsiveMaintainer: number;
   License: number;
-  Dependencies: number;
+  GoodPinningPractice: number;
 }
 
 //get_license_score('git@github.com:davglass/license-checker.git').then(
@@ -50,7 +50,7 @@ async function score_calc(url_parse: URL_PARSE) {
     BusFactor: 0,
     ResponsiveMaintainer: 0,
     License: 0,
-    Dependencies: 0,
+    GoodPinningPractice: 0,
   };
   let temp_dir = '';
   try {
@@ -87,7 +87,7 @@ async function score_calc(url_parse: URL_PARSE) {
       url_parse.github_repo_url
     );
 
-    const dependencies_sub_score = get_dependencies_score(
+    const good_pinning_practice_sub_score = get_good_pinning_practice_score(
       url_parse.github_repo_url,
       git_repo_path
     );
@@ -98,12 +98,12 @@ async function score_calc(url_parse: URL_PARSE) {
     score.ResponsiveMaintainer = Number(
       (await responsiveness_sub_score).toFixed(2)
     );
-    score.RampUp = await ramp_up_sub_score;
-    score.Correctness = await correctness_sub_score;
-    score.Dependencies = await dependencies_sub_score;
+    score.RampUp = Number((await ramp_up_sub_score).toFixed(3));
+    score.Correctness = Number((await correctness_sub_score).toFixed(3));
+    score.GoodPinningPractice = Number((await good_pinning_practice_sub_score).toFixed(3));
 
     // Calculate subscores
-    score.NetScore = net_score_formula(score);
+    score.NetScore = Number(net_score_formula(score).toFixed(3));
   } catch (err) {
     if (err instanceof Error) {
       if (err.message === 'Temporary Directory Creation failed') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-pimport {get_license_score} from './license_score_calc/license';
+import {get_license_score} from './license_score_calc/license';
 import {get_urls, URL_PARSE} from './url_parser';
 import {create_logger} from './logging_setup';
 import {get_bus_factor_score} from './bus_factor/bus_factor';

--- a/tests/_good_pinning_practice_checks/_test_1_empty_dependencies/package.json
+++ b/tests/_good_pinning_practice_checks/_test_1_empty_dependencies/package.json
@@ -1,0 +1,24 @@
+{
+  "devDependencies": {
+    "@types/jest": "^29.4.0",
+    "@types/node": "^14.11.2",
+    "gts": "^3.1.1",
+    "jest": "^29.4.1",
+    "ts-jest": "^29.0.5",
+    "typescript": "^4.9.4"
+  },
+  "scripts": {
+    "lint": "gts lint",
+    "clean": "gts clean",
+    "compile": "tsc",
+    "fix": "gts fix",
+    "prepare": "npm run compile",
+    "pretest": "npm run compile",
+    "posttest": "npm run lint"
+  },
+  "dependencies": {
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  }
+}

--- a/tests/_good_pinning_practice_checks/_test_2_no_dependencies_field/package.json
+++ b/tests/_good_pinning_practice_checks/_test_2_no_dependencies_field/package.json
@@ -1,0 +1,22 @@
+{
+  "devDependencies": {
+    "@types/jest": "^29.4.0",
+    "@types/node": "^14.11.2",
+    "gts": "^3.1.1",
+    "jest": "^29.4.1",
+    "ts-jest": "^29.0.5",
+    "typescript": "^4.9.4"
+  },
+  "scripts": {
+    "lint": "gts lint",
+    "clean": "gts clean",
+    "compile": "tsc",
+    "fix": "gts fix",
+    "prepare": "npm run compile",
+    "pretest": "npm run compile",
+    "posttest": "npm run lint"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  }
+}

--- a/tests/_good_pinning_practice_checks/_test_4_no_pinned_dependencies/package.json
+++ b/tests/_good_pinning_practice_checks/_test_4_no_pinned_dependencies/package.json
@@ -1,0 +1,30 @@
+{
+  "devDependencies": {
+    "@types/jest": "^29.4.0",
+    "@types/node": "^14.11.2",
+    "gts": "^3.1.1",
+    "jest": "^29.4.1",
+    "ts-jest": "^29.0.5",
+    "typescript": "^4.9.4"
+  },
+  "scripts": {
+    "lint": "gts lint",
+    "clean": "gts clean",
+    "compile": "tsc",
+    "fix": "gts fix",
+    "prepare": "npm run compile",
+    "pretest": "npm run compile",
+    "posttest": "npm run lint"
+  },
+  "dependencies": {
+    "array-to-ndjson": "^1.0.1",
+    "axios": "^1.3.2",
+    "dotenv": "^16.0.3",
+    "get-package-github-url": "^1.0.5",
+    "util": "^0.12.5",
+    "winston": "^3.8.2"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  }
+}

--- a/tests/_good_pinning_practice_checks/_test_5_one_pinned_dependency/package.json
+++ b/tests/_good_pinning_practice_checks/_test_5_one_pinned_dependency/package.json
@@ -1,0 +1,30 @@
+{
+  "devDependencies": {
+    "@types/jest": "^29.4.0",
+    "@types/node": "^14.11.2",
+    "gts": "^3.1.1",
+    "jest": "^29.4.1",
+    "ts-jest": "^29.0.5",
+    "typescript": "^4.9.4"
+  },
+  "scripts": {
+    "lint": "gts lint",
+    "clean": "gts clean",
+    "compile": "tsc",
+    "fix": "gts fix",
+    "prepare": "npm run compile",
+    "pretest": "npm run compile",
+    "posttest": "npm run lint"
+  },
+  "dependencies": {
+    "array-to-ndjson": "^1.0.1",
+    "axios": "^1.3.2",
+    "dotenv": "^16.0.3",
+    "get-package-github-url": "^1.0.5",
+    "util": "^0.12.5",
+    "winston": "3.8.2"
+  },
+  "engines": {
+    "node": ">=14.0.0"
+  }
+}

--- a/tests/good_pinning_practice/good_pinning_practice.test.ts
+++ b/tests/good_pinning_practice/good_pinning_practice.test.ts
@@ -1,4 +1,4 @@
-import {get_good_pinning_practice_score} from '../../src/good_pinning_practice_factor/good_pinning_practice';
+import {get_good_pinning_practice_score, check_if_pinned} from '../../src/good_pinning_practice_factor/good_pinning_practice';
 
 describe('testing get_good_pinning_practice_score', () => {
   test('get_good_pinning_practice empty dependencies', async () => {
@@ -26,4 +26,29 @@ describe('testing get_good_pinning_practice_score', () => {
       await get_good_pinning_practice_score('url', './tests/_good_pinning_practice_checks/_test_5_one_pinned_dependency')
     ).toBe(0.5);
   });
+});
+
+describe('testing check_if_pinned regex', () => {
+  test('check_if_pinned valid', async () => {
+    expect(
+      check_if_pinned("1.3.1")
+    ).toBe(true);
+  });
+  // this one may need to be true if patch isn't needed ... check  regex
+  test('check_if_pinned invalid not specified patch (need 2.3.X 3 digit)', async () => {
+    expect(
+      check_if_pinned("1.3")
+    ).toBe(false);
+  });
+  test('check_if_pinned named meta', async () => {
+    expect(
+      check_if_pinned("1.1.2+meta")
+    ).toBe(true);
+  });
+  test('check_if_pinned invalid ranging', async () => {
+    expect(
+      check_if_pinned("1.2.7 || >=1.2.9 <2.0.0")
+    ).toBe(false);
+  });
+  // Add more if tilde or 1.2.x is valid -discuss
 });

--- a/tests/good_pinning_practice/good_pinning_practice.test.ts
+++ b/tests/good_pinning_practice/good_pinning_practice.test.ts
@@ -1,0 +1,29 @@
+import {get_good_pinning_practice_score} from '../../src/good_pinning_practice_factor/good_pinning_practice';
+
+describe('testing get_good_pinning_practice_score', () => {
+  test('get_good_pinning_practice empty dependencies', async () => {
+    expect(
+      await get_good_pinning_practice_score('url', './tests/_good_pinning_practice_checks/_test_1_empty_dependencies')
+    ).toBe(1);
+  });
+  test('get_good_pinning_practice no dependencies field', async () => {
+    expect(
+      await get_good_pinning_practice_score('url', './tests/_good_pinning_practice_checks/_test_2_no_dependencies_field')
+    ).toBe(1);
+  });
+  test('get_good_pinning_practice no package.json present', async () => {
+    expect(
+      await get_good_pinning_practice_score('url', './tests/_good_pinning_practice_checks/_test_3_no_package_json')
+    ).toBe(0);
+  });
+  test('get_good_pinning_practice lots of dependencies, none pinned', async () => {
+    expect(
+      await get_good_pinning_practice_score('url', './tests/_good_pinning_practice_checks/_test_4_no_pinned_dependencies')
+    ).toBe(1);
+  });
+  test('get_good_pinning_practice lots of dependencies, one pinned', async () => {
+    expect(
+      await get_good_pinning_practice_score('url', './tests/_good_pinning_practice_checks/_test_5_one_pinned_dependency')
+    ).toBe(0.5);
+  });
+});


### PR DESCRIPTION
May need to alter regex upon further research, but this is a good implementation with test cases.

Iterates through "dependencies" field of a package's package.json and checks if it is versioned with semver pinned version.
Right now ~ tilde ranging is not allowed and only pinned versions 1.2.3 or 1.2.3+meta work, for example.

Need to determine if 1.2.x is valid x-ranging for major/minor versioning, or if tilde ~ patch versioning is valid. Would like to merge this and fix regex as needed on another branch. 

The title "Good Pinning Practices" metric is from the sample yaml provided to us in the get repository score example request/response.