### PR TITLE
PercReviewedPR Metric completed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@octokit/graphql": "^5.0.5",
         "array-to-ndjson": "^1.0.1",
         "axios": "^1.3.2",
         "dotenv": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -18,15 +18,16 @@
     "posttest": "npm run lint"
   },
   "dependencies": {
+    "@octokit/graphql": "^5.0.5",
     "array-to-ndjson": "^1.0.1",
     "axios": "^1.3.2",
     "dotenv": "^16.0.3",
     "get-package-github-url": "^1.0.5",
     "mariadb": "^3.1.0",
+    "node-fetch": "^2.6.9",
     "octokit": "^2.0.14",
     "util": "^0.12.5",
-    "winston": "^3.8.2",
-    "node-fetch": "^2.6.9"
+    "winston": "^3.8.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,13 +32,15 @@ interface SCORE_OUT {
 
 function net_score_formula(subscores: SCORE_OUT): number {
   // prettier-ignore
-  // Temp fix to include ramp up in net score calc
+  // include 2 new metrics for Part 2
   const net_score: number =
   subscores.License * (
     (subscores.RampUp * 0.3) +
-    (subscores.BusFactor * 0.3) +
-    (subscores.ResponsiveMaintainer * 0.2) +
-    (subscores.Correctness * 0.2)
+    (subscores.BusFactor * 0.2) +
+    (subscores.ResponsiveMaintainer * 0.05) +
+    (subscores.Correctness * 0.2) +
+    (subscores.GoodPinningPractice * 0.2) +
+    (subscores.PercReviewedPR * 0.05)
   );
   return net_score;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {join} from 'path';
 import {get_ramp_up_score} from './ramp_up_factor/ramp_up';
 import {get_correctness_score} from './correctness/correctness';
 import {get_good_pinning_practice_score} from './good_pinning_practice_factor/good_pinning_practice';
+import {get_perc_reviewed_pr_score} from './perc_reviewed_pr_factor/perc_reviewed_pr';
 
 const arrayToNdjson = require('array-to-ndjson');
 
@@ -20,6 +21,7 @@ interface SCORE_OUT {
   ResponsiveMaintainer: number;
   License: number;
   GoodPinningPractice: number;
+  PercReviewedPR: number;
 }
 
 //get_license_score('git@github.com:davglass/license-checker.git').then(
@@ -51,6 +53,7 @@ async function score_calc(url_parse: URL_PARSE) {
     ResponsiveMaintainer: 0,
     License: 0,
     GoodPinningPractice: 0,
+    PercReviewedPR: 0,
   };
   let temp_dir = '';
   try {
@@ -92,6 +95,10 @@ async function score_calc(url_parse: URL_PARSE) {
       git_repo_path
     );
 
+    const perc_reviewed_pr_sub_score = get_perc_reviewed_pr_score(
+      url_parse.github_repo_url
+    );
+
     // Resolve subscores
     score.License = await license_sub_score;
     score.BusFactor = Number((await bus_factor_sub_score).toFixed(3));
@@ -102,6 +109,9 @@ async function score_calc(url_parse: URL_PARSE) {
     score.Correctness = Number((await correctness_sub_score).toFixed(3));
     score.GoodPinningPractice = Number(
       (await good_pinning_practice_sub_score).toFixed(3)
+    );
+    score.PercReviewedPR = Number(
+      (await perc_reviewed_pr_sub_score).toFixed(3)
     );
 
     // Calculate subscores

--- a/src/perc_reviewed_pr_factor/perc_reviewed_pr.ts
+++ b/src/perc_reviewed_pr_factor/perc_reviewed_pr.ts
@@ -1,13 +1,20 @@
-import {fetch_graphql_data} from './perc_reviewed_pr_graphql';
+import {fetch_score_with_graphql_data} from './perc_reviewed_pr_graphql';
 
 export async function get_perc_reviewed_pr_score(
   repo_url: string
 ): Promise<number> {
-  const score = 0;
-  console.log(repo_url);
-  let tmp: number | undefined = 0;
-  tmp = await fetch_graphql_data(repo_url);
-  console.log(tmp);
-  console.log(score);
-  return 0;
+  const score: number | undefined = await fetch_score_with_graphql_data(
+    repo_url
+  );
+  if (score !== undefined) {
+    globalThis.logger.info(
+      `%PR metric calculation: Finished with score ${score}\n`
+    );
+    return score;
+  } else {
+    globalThis.logger.info(
+      '%PR metric calculation undefined: Finished with score 0'
+    );
+    return 0;
+  }
 }

--- a/src/perc_reviewed_pr_factor/perc_reviewed_pr.ts
+++ b/src/perc_reviewed_pr_factor/perc_reviewed_pr.ts
@@ -1,0 +1,13 @@
+import {fetch_graphql_data} from './perc_reviewed_pr_graphql';
+
+export async function get_perc_reviewed_pr_score(
+  repo_url: string
+): Promise<number> {
+  const score = 0;
+  console.log(repo_url);
+  let tmp: number | undefined = 0;
+  tmp = await fetch_graphql_data(repo_url);
+  console.log(tmp);
+  console.log(score);
+  return 0;
+}

--- a/src/perc_reviewed_pr_factor/perc_reviewed_pr_graphql.ts
+++ b/src/perc_reviewed_pr_factor/perc_reviewed_pr_graphql.ts
@@ -51,28 +51,99 @@ export async function fetch_graphql_data(
   if (owner_repo === undefined) {
     return undefined;
   }
-  let result: GraphQlQueryResponseData | undefined = undefined;
-  result = undefined;
+
   try {
-    const allContributions = await graphql({
-      query: `query NewQuery($repo: String!, $owner: String!) {
-				  repository(owner: $owner, name: $repo) {
-				    object(expression: "master") {
-				      ... on Commit {
-				        history {
-				          totalCount
-				        }
-				      }
-				    }
-				  }
-				}`,
+    let query_result: GraphQlQueryResponseData | undefined = undefined;
+    let tot_commit_count = 0;
+    query_result = await graphql({
+      query: `query PR_TOTCOMMIT_Query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    object(expression: "master") {
+      ... on Commit {
+        history {
+          totalCount
+        }
+      }
+    }
+  }
+}`,
       owner: owner_repo.owner,
       repo: owner_repo.repo,
       headers: {
         authorization: 'bearer ' + process.env.GITHUB_TOKEN,
       },
     });
-    console.log(allContributions);
+    if (query_result !== undefined) {
+      const jdata = JSON.parse(JSON.stringify(query_result));
+      tot_commit_count = jdata.repository.object.history.totalCount;
+      console.log(tot_commit_count);
+    } else {
+      globalThis.logger?.info(
+        '%PR Factor: could not get total commit count of repo - returning 0.'
+      );
+      return 0;
+    }
+    if (tot_commit_count === 0) {
+      globalThis.logger?.info(
+        '%PR Factor: Total commit count of repo is 0 - returning 0.'
+      );
+      return 0;
+    }
+
+    // find commit count of PR/Reviewed commits (first pagination without loop, first 100)
+    let query_result_pre_loop: GraphQlQueryResponseData | undefined = undefined;
+    let tot_commit_with_reviewed_pr = 0;
+    let tot_pr_count = 0;
+    let has_next_page = false;
+    let end_cursor = "";
+    query_result_pre_loop = await graphql({
+      query: `query PR_REAL_FIRST_Query($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(states: MERGED, first: 100) {
+      totalCount
+      nodes {
+        reviews(states: APPROVED) {
+          totalCount
+        }
+        commits {
+          totalCount
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+}`,
+      owner: owner_repo.owner,
+      repo: owner_repo.repo,
+      headers: {
+        authorization: 'bearer ' + process.env.GITHUB_TOKEN,
+      },
+    });
+    if (query_result_pre_loop !== undefined) {
+      const jdata = JSON.parse(JSON.stringify(query_result_pre_loop));
+      tot_pr_count = jdata.repository.pullRequests.totalCount;
+      has_next_page = jdata.repository.pullRequests.pageInfo.hasNextPage;
+      end_cursor = jdata.repository.pullRequests.pageInfo.endCursor;
+      console.log(tot_pr_count);
+      console.log(typeof has_next_page);
+      console.log(has_next_page);
+      console.log(typeof end_cursor);
+      console.log(end_cursor);
+    } else {
+      globalThis.logger?.info(
+        '%PR Factor: could not get total PR count of repo - returning 0.'
+      );
+      return 0;
+    }
+    if (tot_pr_count === 0) {
+      globalThis.logger?.info(
+        '%PR Factor: Total PR count of repo is 0 - returning 0.'
+      );
+      return 0;
+    }
   } catch (error) {
     if (error instanceof GraphqlResponseError) {
       globalThis.logger?.error(
@@ -83,6 +154,7 @@ export async function fetch_graphql_data(
         '%PR Factor: GraphQL call failed for reason unknown!'
       );
     }
+    return 0;
   }
   console.log(owner_repo);
   return 1;

--- a/src/perc_reviewed_pr_factor/perc_reviewed_pr_graphql.ts
+++ b/src/perc_reviewed_pr_factor/perc_reviewed_pr_graphql.ts
@@ -1,0 +1,89 @@
+import {graphql, GraphqlResponseError} from '@octokit/graphql';
+import type {GraphQlQueryResponseData} from '@octokit/graphql';
+
+interface OWNER_REPO {
+  github_repo_url: string;
+  owner: string | undefined;
+  repo: string | undefined;
+}
+
+function get_owner_repo(github_repo_url: string): OWNER_REPO | undefined {
+  try {
+    const url_obj: URL = new URL(github_repo_url);
+    const host: string = url_obj.host;
+    let pathname: string = url_obj.pathname;
+    let url_owner: string | undefined = undefined;
+    let url_repo: string | undefined = undefined;
+    if (host === 'github.com') {
+      if (pathname.startsWith('/')) {
+        pathname = pathname.slice(1);
+      }
+      url_owner = pathname.slice(0, pathname.indexOf('/'));
+      url_repo = pathname.slice(pathname.indexOf('/') + 1);
+    } else {
+      return undefined;
+    }
+    const owner_repo: OWNER_REPO = {
+      github_repo_url: github_repo_url,
+      owner: url_owner,
+      repo: url_repo,
+    };
+    if (owner_repo.owner === undefined || owner_repo.repo === undefined) {
+      return undefined;
+    }
+    if (owner_repo.owner === '' || owner_repo.repo === '') {
+      return undefined;
+    }
+    return owner_repo;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function fetch_graphql_data(
+  github_repo_url: string
+): Promise<number | undefined> {
+  if (process.env.GITHUB_TOKEN === undefined) {
+    throw new Error('GITHUB_TOKEN is not defined');
+  }
+
+  const owner_repo = get_owner_repo(github_repo_url);
+  if (owner_repo === undefined) {
+    return undefined;
+  }
+  let result: GraphQlQueryResponseData | undefined = undefined;
+  result = undefined;
+  try {
+    const allContributions = await graphql({
+      query: `query NewQuery($repo: String!, $owner: String!) {
+				  repository(owner: $owner, name: $repo) {
+				    object(expression: "master") {
+				      ... on Commit {
+				        history {
+				          totalCount
+				        }
+				      }
+				    }
+				  }
+				}`,
+      owner: owner_repo.owner,
+      repo: owner_repo.repo,
+      headers: {
+        authorization: 'bearer ' + process.env.GITHUB_TOKEN,
+      },
+    });
+    console.log(allContributions);
+  } catch (error) {
+    if (error instanceof GraphqlResponseError) {
+      globalThis.logger?.error(
+        '%PR Factor: GraphQL call failed: ${error.message}'
+      );
+    } else {
+      globalThis.logger?.error(
+        '%PR Factor: GraphQL call failed for reason unknown!'
+      );
+    }
+  }
+  console.log(owner_repo);
+  return 1;
+}


### PR DESCRIPTION
Finished implementation of the percent of the codebase that was introduced via PR with a review. 
	Description of how this metric is calculated:
	1. check if GITHUB_TOKEN defined, throw error if not
	2. get owner/repo strings from github URL input to be used in GraphQL queries
	3. GraphQL query to fetch total commit count of the repository
	4. GraphQL query to fetch nodes of each PR in the repository
	that was merged into master, also checking for commit count of each PR
	and whether it had an APPROVING review. First query returns first 100
	PRs and a pagination return of if there is another page and the end cursor if so.
	5. If there is more than 100 PRs, pagination loop starts. This loop
	performs a similar query to (4) but with pagination, getting the first 100
	PRs after the last end cursor.
	6. Accumulate the total count of commits by adding a PR's commit count when a merged PR is found that has
	a minimum of 1 approving review.
	7. Once pagination is complete, the accumulation is also completed.
	8. The final score of "% of codebase that was written with a PR and a review"
	is the accumulated commit count of each merged PR with an approving review /
	the total commit count of the repo fetched in (3).

I also updated the net score calculations - feel free to change this.
Unsure if this is great since all are very low scoring, but this is exactly what the specs asked for.
