### PR TITLE
Priyanka input sizecost

### DIFF
--- a/src/api_server/api/p2spec.yaml
+++ b/src/api_server/api/p2spec.yaml
@@ -21,7 +21,7 @@ paths:
             schema:
               type: array
               items:
-                $ref: '#/components/schemas/PackageName'
+                $ref: '#/components/schemas/SizecostInput'
         required: true
       responses:
         "200":
@@ -34,14 +34,14 @@ paths:
                   value:
                   - names: underscore, lodash
                     size: 12800
-          description: Net size cost of all input packages
+          description: Net size cost of all input packages in bytes
         "400":
           description: "There is missing field(s) in the SizeCost Query of package names/AuthenticationToken
             \ or it is formed improperly, or the AuthenticationToken is invalid."  
       summary: Get the "what if" size cost of introducing the package to the registry.
       description: |-
         Get the size cost (in bytes) of introducing the package to the registry.
-        Accepts array input of PackageNames (must be npm, public, lowercase, not internal)
+        Accepts array input of SizecostInput objs (Either Content, URL, or public package name like cloudinary)
         Includes the size cost of transitive dependencies, if already in registry, not double counted.      
     parameters:
     - name: X-Authorization
@@ -643,6 +643,26 @@ components:
         JSProgram:
           description: A JavaScript program (for use with sensitive modules).
           type: string
+    SizecostInput:
+      description: |-
+        This is a "union" type.
+        - Either Content, URL, or Name MUST be set for the /sizecost input to work.
+      type: object
+      properties:
+        Content:
+          description: |-
+            Package contents. This is the zip file uploaded by the user. (Encoded as text using a Base64 encoding).
+
+            This will be a zipped version of an npm package's GitHub repository, minus the ".git/" directory." It will, for example, include the "package.json" file that can be used to retrieve the project homepage.
+
+            See https://docs.npmjs.com/cli/v7/configuring-npm/package-json#homepage.
+          type: string
+        URL:
+          description: Package URL (for use in public ingest).
+          type: string
+        Name:
+          description: name of a public NPM hosted package (just cloudinary, for example)
+          $ref: '#/components/schemas/PackageName'
     User:
       description: ""
       required:

--- a/src/api_server/api/p2spec.yaml
+++ b/src/api_server/api/p2spec.yaml
@@ -22,6 +22,21 @@ paths:
               type: array
               items:
                 $ref: '#/components/schemas/SizecostInput'
+            examples:
+              ExampleRequestWithContent:
+                value:
+                  - Content: UEsDBBQAAAAIANybilZ9HJ7PAwIAADcFAAAMABwAcGFja2FnZS5qc29uVVQJAAMwnDRkMJw0ZHV4CwABBOgDAAAE6AMAAJ1UsW7bMBDd/RWExqKiIjm2i0wtmqUdunRsaoCmzhYdiRRIKrYb5N97JEVJcdUMmQTee/d49+6o5wUhiWQNJHf4VSUcTboXNaSlOslasRJ08tFxnkAboaSj3dI8pzchXILhWrS2h74Ql0zGZLJXmvxA3e8mJDRMeOb9QKHHHgpKBtFnPGLAgrGO2yheMfKBunNk93Aa9QLHnWZpVjSguolaH0g5kxzqmrkOZjO5krzTGiS/jNmT4GzSiVleRUsbJUmawhk4eUhk2xBHeUgS5L/4xh/hclK6dJ3/CiJX7mPkytdp+HpWJE7y9el6NDPof5TeyvwnD6HfvivW2UppZ4LYaVV+WoYp14KDNH7fvv38GreoBVmimwIm49+rulanVEMpNHC/GMk2p/mK5rGCytrWpK1W50vKDiD9gLcretPvp1s4HHRqLy2E/ILmtNhE0DAprPgDfufjM8A71nQ5jqeEp/vZAj972ezYr+m2WNGCFlG7R51JQXWDZRVD6XBusamQt0ZkCmgwoVp8apsR8bsXtFBpbFEq/hjCSxS6jWEtGs32HnDxoTDTtaDj29qu0ZBJs5VqoEUrHebdvcuyg7BVt6NcNVk/yuytX8WuO0xM6nT9Lq1MGNOh20NlGlplhFX6MvlDoMVOHVVjd++9jzqN4TIUFtK3Mf1T2ZLiGi5eFn8BUEsBAh4DFAAAAAgA3JuKVn0cns8DAgAANwUAAAwAGAAAAAAAAQAAALSBAAAAAHBhY2thZ2UuanNvblVUBQADMJw0ZHV4CwABBOgDAAAE6AMAAFBLBQYAAAAAAQABAFIAAABJAgAAAAA=
+              ExampleRequestWithURL:
+                value:
+                  - URL: https://github.com/cloudinary/cloudinary_npm
+              ExampleRequestWithName:
+                value:
+                  - Name: underscore
+              ExampleRequestWithMultipleInputs:
+                value:
+                  - Name: underscore
+                  - URL: https://github.com/cloudinary/cloudinary_npm
+                  - Content: UEsDBBQAAAAIANybilZ9HJ7PAwIAADcFAAAMABwAcGFja2FnZS5qc29uVVQJAAMwnDRkMJw0ZHV4CwABBOgDAAAE6AMAAJ1UsW7bMBDd/RWExqKiIjm2i0wtmqUdunRsaoCmzhYdiRRIKrYb5N97JEVJcdUMmQTee/d49+6o5wUhiWQNJHf4VSUcTboXNaSlOslasRJ08tFxnkAboaSj3dI8pzchXILhWrS2h74Ql0zGZLJXmvxA3e8mJDRMeOb9QKHHHgpKBtFnPGLAgrGO2yheMfKBunNk93Aa9QLHnWZpVjSguolaH0g5kxzqmrkOZjO5krzTGiS/jNmT4GzSiVleRUsbJUmawhk4eUhk2xBHeUgS5L/4xh/hclK6dJ3/CiJX7mPkytdp+HpWJE7y9el6NDPof5TeyvwnD6HfvivW2UppZ4LYaVV+WoYp14KDNH7fvv38GreoBVmimwIm49+rulanVEMpNHC/GMk2p/mK5rGCytrWpK1W50vKDiD9gLcretPvp1s4HHRqLy2E/ILmtNhE0DAprPgDfufjM8A71nQ5jqeEp/vZAj972ezYr+m2WNGCFlG7R51JQXWDZRVD6XBusamQt0ZkCmgwoVp8apsR8bsXtFBpbFEq/hjCSxS6jWEtGs32HnDxoTDTtaDj29qu0ZBJs5VqoEUrHebdvcuyg7BVt6NcNVk/yuytX8WuO0xM6nT9Lq1MGNOh20NlGlplhFX6MvlDoMVOHVVjd++9jzqN4TIUFtK3Mf1T2ZLiGi5eFn8BUEsBAh4DFAAAAAgA3JuKVn0cns8DAgAANwUAAAwAGAAAAAAAAQAAALSBAAAAAHBhY2thZ2UuanNvblVUBQADMJw0ZHV4CwABBOgDAAAE6AMAAFBLBQYAAAAAAQABAFIAAABJAgAAAAA=
         required: true
       responses:
         "200":

--- a/src/api_server/controllers/sizecost_controller.ts
+++ b/src/api_server/controllers/sizecost_controller.ts
@@ -169,11 +169,10 @@ export async function get_size_cost(req: Request, res: Response) {
     }
 
     if (input.length === 0) {
-      globalThis.logger?.info('/sizecost NO INPUTS!!');
+      globalThis.logger?.error('/sizecost NO INPUTS!!');
       res.status(400).send();
       return;
     }
-
 
     // eslint-disable-next-line prefer-const
     let names_arr: PackageName[] = [];
@@ -181,18 +180,36 @@ export async function get_size_cost(req: Request, res: Response) {
     globalThis.logger?.debug(`/sizecost INPUT ${input}`);
     // check if already in packages db and remove from input if so
     for (let i = 0; i < input.length; i++) {
-      globalThis.logger?.debug(`Looping: input[${i}] = ${input[i]}`);
+      globalThis.logger?.debug(`Looping: input[${i}]`);
+      let name = '';
+      if (input[i].Name !== undefined) {
+        globalThis.logger?.debug('/sizecost input type Name');
+        name = input[i].Name;
+      } else if (input[i].URL !== undefined) {
+        globalThis.logger?.debug('/sizecost input type URL');
+        name = 'url-parser';
+      } else if (input[i].Content !== undefined) {
+        globalThis.logger?.debug('/sizecost input type Content');
+        name = 'b64-content';
+      } else {
+        globalThis.logger?.error('/sizecost input type none set!!! error');
+        res.status(400).send();
+        return;
+      }
+
+      globalThis.logger?.debug(`/sizecost name decided ${name}`);
+
       const found = await packages.findOne({
-        where: {PackageName: input[i].Name},
+        where: {PackageName: name},
       });
       if (found) {
-        globalThis.logger?.info(`/sizecost found ${input[i]}`);
+        globalThis.logger?.info(`/sizecost found ${name}`);
         input.splice(i, 1);
       } else {
-        names_arr.push(input[i].Name);
+        names_arr.push(name);
       }
     }
-    if (input.length === 0) {
+    if (names_arr.length === 0) {
       globalThis.logger?.info('/sizecost all alr uploaded, 0');
       const ret1: PackageSizeReturn = {
         names: input.join(),

--- a/src/api_server/controllers/sizecost_controller.ts
+++ b/src/api_server/controllers/sizecost_controller.ts
@@ -189,10 +189,18 @@ export async function get_size_cost(req: Request, res: Response) {
     for (let i = 0; i < input.length; i++) {
       globalThis.logger?.debug(`Looping: input[${i}]`);
       let name = '';
-      if (input[i].Name !== undefined) {
+      if (
+        input[i].Name !== undefined &&
+        input[i].URL === undefined &&
+        input[i].Content === undefined
+      ) {
         globalThis.logger?.debug('/sizecost input type Name');
         name = input[i].Name;
-      } else if (input[i].URL !== undefined) {
+      } else if (
+        input[i].URL !== undefined &&
+        input[i].Name === undefined &&
+        input[i].Content === undefined
+      ) {
         globalThis.logger?.debug('/sizecost input type URL');
         if (check_if_npm(input[i].URL)) {
           name = get_npm_package_name(input[i].URL);
@@ -207,7 +215,11 @@ export async function get_size_cost(req: Request, res: Response) {
           }
           delete_dir(tmp);
         }
-      } else if (input[i].Content !== undefined) {
+      } else if (
+        input[i].Content !== undefined &&
+        input[i].Name === undefined &&
+        input[i].URL === undefined
+      ) {
         globalThis.logger?.debug('/sizecost input type Content');
         const tmp = await create_tmp();
         const check = await unzip_base64_to_dir(input[i].Content, tmp);

--- a/src/api_server/get_files.ts
+++ b/src/api_server/get_files.ts
@@ -78,3 +78,21 @@ export async function find_and_read_readme(
   }
   return null;
 }
+
+export async function find_name_from_packagejson(
+  directory: string
+): Promise<string | undefined> {
+  globalThis.logger?.debug(
+    `dir input to find_and_read_package_json ${directory}`
+  );
+  // getFiles changed so it returns files in base directory first
+  for await (const filename of getFiles(directory)) {
+    if (path.basename(filename) === 'package.json') {
+      const strcontent = await readFile(filename);
+      globalThis.logger?.debug(`found package.json: ${filename}`);
+      const strjson = JSON.parse(strcontent.toString());
+      return strjson.name.toString();
+    }
+  }
+  return undefined;
+}

--- a/src/api_server/models/models.ts
+++ b/src/api_server/models/models.ts
@@ -9,7 +9,7 @@ export interface SizecostInput {
    * @type {string}
    * @memberof SizecostInput
    */
-  content?: string;
+  Content?: string;
   /**
    * Package URL (for use in public ingest).
    * @type {string}

--- a/src/api_server/models/models.ts
+++ b/src/api_server/models/models.ts
@@ -1,5 +1,30 @@
 /**
- * Package size cost introduce in KB
+ * This is a \"union\" type. - Either Content, URL, or Name MUST be set for the /sizecost input to work.
+ * @export
+ * @interface SizecostInput
+ */
+export interface SizecostInput {
+  /**
+   * Package contents. This is the zip file uploaded by the user. (Encoded as text using a Base64 encoding).  This will be a zipped version of an npm package's GitHub repository, minus the \".git/\" directory.\" It will, for example, include the \"package.json\" file that can be used to retrieve the project homepage.  See https://docs.npmjs.com/cli/v7/configuring-npm/package-json#homepage.
+   * @type {string}
+   * @memberof SizecostInput
+   */
+  content?: string;
+  /**
+   * Package URL (for use in public ingest).
+   * @type {string}
+   * @memberof SizecostInput
+   */
+  URL?: string;
+  /**
+   *
+   * @type {PackageName}
+   * @memberof SizecostInput
+   */
+  Name?: PackageName;
+}
+/**
+ * Package size cost introduce in bytes
  * @export
  */
 export type PackageSize = number;


### PR DESCRIPTION
Updated sizecost to have input types of Content, URL, or Name. An array of these are passed in (with each array entry being an object  with ONE of these fields set). This allows for any possible package input to be tested for size cost.

Completes the implementation of size cost including ~30 test cases, with upload, delete, various input types, shared transitive dependencies, no shared transitive dependencies, and more being checked.